### PR TITLE
Move Xcodes to main.swift

### DIFF
--- a/xcodereleases/Model/Xcode.swift
+++ b/xcodereleases/Model/Xcode.swift
@@ -8,8 +8,6 @@
 
 import Foundation
 
-let xcodes: Array<Xcode> = xcodes11 + xcodes10 + xcodes9 + xcodes8 + xcodes7 + xcodes6 + xcodes5 + xcodes4 + xcodes3 + xcodes2 + xcodes1
-
 struct Xcode: Codable {
     let name: String
     let version: Version

--- a/xcodereleases/main.swift
+++ b/xcodereleases/main.swift
@@ -8,6 +8,8 @@
 
 import Foundation
 
+let xcodes: Array<Xcode> = xcodes11 + xcodes10 + xcodes9 + xcodes8 + xcodes7 + xcodes6 + xcodes5 + xcodes4 + xcodes3 + xcodes2 + xcodes1
+
 var encoder = JSONEncoder()
 //encoder.outputFormatting = .prettyPrinted
 do {


### PR DESCRIPTION
The `xcodes` array couples the Models to the Data. If those two would be decoupled I could use the Models as a submodule of https://github.com/bearologics/tailor.