### PR TITLE
Remove Invalid Xcode 8.3.1

### DIFF
--- a/Sources/XCData/Xcode8.swift
+++ b/Sources/XCData/Xcode8.swift
@@ -29,15 +29,6 @@ let xcodes8: Array<Xcode> = [
                        notes: Link("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW853")),
           checksums: Checksums(sha1: "4e7e97e6e2c5c92432a04e657dfe94226849cb51")),
 
-    Xcode(version: V("8E1000a", "8.3.1"),
-          date: (2017, 04, 06),
-          requires: "10.12",
-          sdks: SDKs(macOS: V("16E185"), iOS: V("14E269"), watchOS: V("14V243"), tvOS: V("14W260")),
-          compilers: Compilers(clang: V("802.0.41", "8.1.0"), swift: V("802.0.51", "3.1")),
-          links: Links(download: Link("https://download.developer.apple.com/Developer_Tools/Xcode_8.3.1/Xcode_8.3.1.xip"),
-                       notes: Link("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW848")),
-          checksums: Checksums(sha1: "320e0c26daec62ef2fbc67bac26642fc6f2b0a90")),
-
     Xcode(version: V("8E162", "8.3"),
           date: (2017, 03, 27),
           requires: "10.12",


### PR DESCRIPTION
Xcode 8.3.1 is no longer available for download and should be removed.

https://github.com/inloco/xcode/runs/5671000956?check_suite_focus=true

```bash
make: *** [Xcode.xip]
$ aria2c --load-cookies='cookies.txt' --max-connection-per-server='16' --split='16' --stderr 'https://download.developer.apple.com/Developer_Tools/Xcode_8.3.1/Xcode_8.3.1.xip'

Notice: :44:56 [NOTICE] Downloading 1 item(s)

Error: 3:44:56 [ERROR] CUID#7 - Download aborted. URI=https://download.developer.apple.com/Developer_Tools/Xcode_8.3.1/Xcode_8.3.1.xip
Exception: [AbstractCommand.cc:351] errorCode=22 URI=https://download.developer.apple.com/Developer_Tools/Xcode_8.3.1/Xcode_8.3.1.xip
  -> [HttpSkipResponseCommand.cc:239] errorCode=22 The response status is not successful. status=403

Notice: :44:56 [NOTICE] Download GID#a4d27401805ace3d not complete: 

Download Results:
gid   |stat|avg speed  |path/URI
======+====+===========+=======================================================
a4d274|ERR |       0B/s|https://download.developer.apple.com/Developer_Tools/Xcode_8.3.1/Xcode_8.3.1.xip

Status Legend:
(ERR):error occurred.

aria2 will resume download if the transfer is restarted.
If there are any errors, then see the log file. See '-l' option in help/man page for details.
make: *** [Makefile:34: Xcode.xip] Error 22
```

![image](https://user-images.githubusercontent.com/7753096/159836967-d70a4269-5534-4b8c-bf1c-32f1c047d550.png)
