### PR TITLE
Fix download links for Xcode 4.3 - 6.1.1

### DIFF
--- a/Sources/XCData/Xcode4.swift
+++ b/Sources/XCData/Xcode4.swift
@@ -156,7 +156,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5.2/Xcode_4.5.2.dmg",
-                   sha1: "2dea0b49f9f35b91ad2abc7f3b71889679febac1"),
+                   sha1: "8abedc3686855caea06958477e1b5575c7f652ba"),
             .notes("https://download.developer.apple.com/Developer_Tools/xcode_4.5.2/release_notes_xcode_4.5.2.pdf")
           ]),
 
@@ -315,7 +315,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.4_21362/Xcode_4.4.dmg",
-                   sha1: "d04393543564f85c2f4d82e507d596d3070e9aba"),
+                   sha1: "4177eb557b28faabe071293dfbb552bfc2f35a50"),
             .notes("https://download.developer.apple.com/Developer_Tools/xcode_4.4_21362/release_notes_xcode44gm.pdf")
           ]),
 
@@ -393,7 +393,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.2.1_for_lion_21265/installxcode_421_lion.dmg",
-                   sha1: "8abedc3686855caea06958477e1b5575c7f652ba")
+                   sha1: "2f800aadc6b51092e0375d34ac45702bcef59f5c")
           ]),
 
     Xcode(number: "4.2",

--- a/Sources/XCData/Xcode4.swift
+++ b/Sources/XCData/Xcode4.swift
@@ -28,7 +28,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.3/Xcode_4.6.3.dmg",
-                   sha1: "f8f9d8a3eec9c46072c02e0007f6abe411e674f8"),
+                   sha1: "2992dc9ab74efabb26534f74239e6fe3f39d5bbd"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW600")
           ]),
 
@@ -49,7 +49,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.2/Xcode_4.6.2.dmg",
-                   sha1: "5b1918ac6173f6444196cf497a419d79970608c2"),
+                   sha1: "1e4d8420e2ab768ce5e87605bbd3fde43e4eb3ef"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW603")
           ]),
 
@@ -70,7 +70,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.1/Xcode_4.6.1.dmg",
-                   sha1: "a3bde15a30da0faba2080fb91ef65cdf7956a1ed"),
+                   sha1: "7685218281a03e3ae04f4780849e13f57a240261"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW612")
           ]),
 
@@ -177,7 +177,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5.1/Xcode_4.5.1.dmg",
-                   sha1: "1a9e80e73f23ca0b6da961c0b691f1a94fe7e348"),
+                   sha1: "9f9cb35c4c937592f6de9e980ebb1cf2aeede590"),
             .notes("https://download.developer.apple.com/Developer_Tools/xcode_4.5.1/release_notes_xcode_4.5.1.pdf")
           ]),
 
@@ -198,7 +198,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5/Xcode_4.5.dmg",
-                   sha1: "e461491c9251bb955ce60e2f7d7dfbc5f934321d"),
+                   sha1: "698d4f7477626f8589491dc07e850c5d78ced163"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW643")
           ]),
 
@@ -219,7 +219,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.4.1/Xcode_4.4.1.dmg",
-                   sha1: "4b8e927c7c58885fe91a36a21952604285b8d60f"),
+                   sha1: "d96d6a3391a4f89d56dab25112fecf927d003cff"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW670")
           ]),
 
@@ -279,7 +279,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.3_for_lion/Xcode_4.3.3_for_Lion.dmg",
-                   sha1: "d806ca8937b43a22d2f4e7c9ad8cc06e2a7298d8")
+                   sha1: "9c7b332154b7be64e789e9e9addd1a02284a033e")
           ]),
 
     Xcode(number: "4.3.2",
@@ -297,7 +297,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.2/Xcode_4.3.2_for_Lion.dmg",
-                   sha1: "8e2723f24f2a58af78317c115e1dc8e4f3c96b43")
+                   sha1: "b656383c7cb37beaa6aeaf19c3b4d92f372aaeee")
           ]),
 
     Xcode(number: "4.4",
@@ -334,7 +334,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.1_for_lion_21267/Xcode_4.3.1_for_Lion.dmg",
-                   sha1: "82d89d4029665cca28d806361e4607d9875ac9a4")
+                   sha1: "084f8043b0d3cc70d15264b4cbeb7e467b07e4d0")
           ]),
 
     Xcode(number: "4.4",
@@ -361,7 +361,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3_for_lion_21266/Xcode_4.3_for_Lion.dmg",
-                   sha1: "be666d0285f492463ae4c189d265612a83cbf296"),
+                   sha1: "7fddfb70113e254c13097d2027ef4bbec1219403"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW699")
           ]),
 
@@ -393,7 +393,7 @@ let xcodes4: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.2.1_for_lion_21265/installxcode_421_lion.dmg",
-                   sha1: "2f800aadc6b51092e0375d34ac45702bcef59f5c")
+                   sha1: "8abedc3686855caea06958477e1b5575c7f652ba")
           ]),
 
     Xcode(number: "4.2",

--- a/Sources/XCData/Xcode4.swift
+++ b/Sources/XCData/Xcode4.swift
@@ -27,7 +27,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.1", build: "425.0.28")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.3/xcode4630916281a.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.3/Xcode_4.6.3.dmg",
                    sha1: "f8f9d8a3eec9c46072c02e0007f6abe411e674f8"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW600")
           ]),
@@ -48,7 +48,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.1", build: "425.0.28")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.2/xcode4620419895a.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.2/Xcode_4.6.2.dmg",
                    sha1: "5b1918ac6173f6444196cf497a419d79970608c2"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW603")
           ]),
@@ -69,7 +69,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.1", build: "425.0.27")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.1/xcode4610419628a.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.6.1/Xcode_4.6.1.dmg",
                    sha1: "a3bde15a30da0faba2080fb91ef65cdf7956a1ed"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW612")
           ]),
@@ -155,7 +155,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.1", build: "421.11.66")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5.2/xcode4520418508a.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5.2/Xcode_4.5.2.dmg",
                    sha1: "2dea0b49f9f35b91ad2abc7f3b71889679febac1"),
             .notes("https://download.developer.apple.com/Developer_Tools/xcode_4.5.2/release_notes_xcode_4.5.2.pdf")
           ]),
@@ -176,7 +176,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.1", build: "421.11.66")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5.1/xcode4510417539a.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5.1/Xcode_4.5.1.dmg",
                    sha1: "1a9e80e73f23ca0b6da961c0b691f1a94fe7e348"),
             .notes("https://download.developer.apple.com/Developer_Tools/xcode_4.5.1/release_notes_xcode_4.5.1.pdf")
           ]),
@@ -197,7 +197,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.1", build: "421.11.65")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5/xcode_4.5.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.5/Xcode_4.5.dmg",
                    sha1: "e461491c9251bb955ce60e2f7d7dfbc5f934321d"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW643")
           ]),
@@ -218,7 +218,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.0", build: "421.0.60")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.4.1/xcode_4.4.1_6938145.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.4.1/Xcode_4.4.1.dmg",
                    sha1: "4b8e927c7c58885fe91a36a21952604285b8d60f"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW670")
           ]),
@@ -278,7 +278,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "3.1", build: "318.0.61")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.3_for_lion/xcode_4.3.3_for_lion.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.3_for_lion/Xcode_4.3.3_for_Lion.dmg",
                    sha1: "d806ca8937b43a22d2f4e7c9ad8cc06e2a7298d8")
           ]),
 
@@ -296,7 +296,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "3.1", build: "318.0.58")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.2/xcode_432_lion.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.2/Xcode_4.3.2_for_Lion.dmg",
                    sha1: "8e2723f24f2a58af78317c115e1dc8e4f3c96b43")
           ]),
 
@@ -314,7 +314,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "4.0", build: "421.0.57")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.4_21362/xcode446938108a.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.4_21362/Xcode_4.4.dmg",
                    sha1: "d04393543564f85c2f4d82e507d596d3070e9aba"),
             .notes("https://download.developer.apple.com/Developer_Tools/xcode_4.4_21362/release_notes_xcode44gm.pdf")
           ]),
@@ -333,7 +333,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "3.1", build: "318.0.54")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.1_for_lion_21267/xcode_431_lion.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3.1_for_lion_21267/Xcode_4.3.1_for_Lion.dmg",
                    sha1: "82d89d4029665cca28d806361e4607d9875ac9a4")
           ]),
 
@@ -360,7 +360,7 @@ let xcodes4: Array<Xcode> = [
             .clang(number: "3.1", build: "318.0.45")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3_for_lion_21266/xcode_43_lion.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_4.3_for_lion_21266/Xcode_4.3_for_Lion.dmg",
                    sha1: "be666d0285f492463ae4c189d265612a83cbf296"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW699")
           ]),

--- a/Sources/XCData/Xcode5.swift
+++ b/Sources/XCData/Xcode5.swift
@@ -21,7 +21,7 @@ let xcodes5: Array<Xcode> = [
             .clang(number: "5.1", build: "503.0.40")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.1.1/xcode_5.1.1.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.1.1/Xcode_5.1.1.dmg",
                    sha1: "e4bb45174324c3a4b7c66fa1db1083ccbbe2334e"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW504")
           ]),
@@ -36,7 +36,7 @@ let xcodes5: Array<Xcode> = [
             .clang(number: "5.1", build: "503.0.38")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.1/xcode_5.1.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.1/Xcode_5.1.dmg",
                    sha1: "7ee6f5917078f1fd509e539f1bde85d85ec23b20"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW512")
           ]),
@@ -81,7 +81,7 @@ let xcodes5: Array<Xcode> = [
             .clang(number: "5.0", build: "500.2.79")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.0.2/xcode_5.0.2.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.0.2/Xcode_5.0.2.dmg",
                    sha1: "de23e3f4644dbb434ed862a3ce002e2de555f6f2"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW536")
           ]),
@@ -96,7 +96,7 @@ let xcodes5: Array<Xcode> = [
             .clang(number: "5.0", build: "500.2.79")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.0.1/xcode_5.0.1.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.0.1/Xcode_5.0.1.dmg",
                    sha1: "8d24b0ee4761ea4135a58c1dd915fce81360e1e7"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW544")
           ]),
@@ -117,7 +117,7 @@ let xcodes5: Array<Xcode> = [
             .clang(number: "5.0", build: "500.2.75")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5/xcode_5.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5/Xcode_5.dmg",
                    sha1: "991ea0361c13f92d6cd7e31644dcdc1f329ffe03"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW578")
           ]),

--- a/Sources/XCData/Xcode5.swift
+++ b/Sources/XCData/Xcode5.swift
@@ -22,7 +22,7 @@ let xcodes5: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.1.1/Xcode_5.1.1.dmg",
-                   sha1: "e4bb45174324c3a4b7c66fa1db1083ccbbe2334e"),
+                   sha1: "f88f50b4bca04022d49f7046cb02240596757aa3"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW504")
           ]),
 
@@ -82,7 +82,7 @@ let xcodes5: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.0.2/Xcode_5.0.2.dmg",
-                   sha1: "de23e3f4644dbb434ed862a3ce002e2de555f6f2"),
+                   sha1: "3636f71eb036ab5818b5c10b7d758c8c06bf78af"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW536")
           ]),
 
@@ -97,7 +97,7 @@ let xcodes5: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5.0.1/Xcode_5.0.1.dmg",
-                   sha1: "8d24b0ee4761ea4135a58c1dd915fce81360e1e7"),
+                   sha1: "c4972cd8d7473817ada4e985e1e6eb5c5b69133f"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW544")
           ]),
 
@@ -118,7 +118,7 @@ let xcodes5: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_5/Xcode_5.dmg",
-                   sha1: "991ea0361c13f92d6cd7e31644dcdc1f329ffe03"),
+                   sha1: "e12bd921435f5859aff6404f6b630cafa003f890"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW578")
           ]),
 

--- a/Sources/XCData/Xcode6.swift
+++ b/Sources/XCData/Xcode6.swift
@@ -209,7 +209,7 @@ let xcodes6: Array<Xcode> = [
             .swift(number: "1.1", build: "600.0.56.1")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.1.1/xcode_6.1.1.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.1.1/Xcode_6.1.1.dmg",
                    sha1: "a54e4b327889e3ee3c952ef5292adc076c21df02"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW423")
           ]),
@@ -237,7 +237,7 @@ let xcodes6: Array<Xcode> = [
             .swift(number: "1.1", build: "600.0.54.20")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.1/56841_xcode_6.1.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.1/Xcode_6.1.dmg",
                    sha1: "4fc070a1347cc880ab2ed2225a7c9e4d5d6515c0"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW432")
           ]),
@@ -269,7 +269,7 @@ let xcodes6: Array<Xcode> = [
             .swift(number: "1.0", build: "600.0.51.4")
           ],
           links: [
-            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.0.1/xcode_6.0.1.dmg",
+            .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.0.1/Xcode_6.0.1.dmg",
                    sha1: "496d56181861dd7ed1807895897d45403eb4ed44"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW450")
           ]),

--- a/Sources/XCData/Xcode6.swift
+++ b/Sources/XCData/Xcode6.swift
@@ -10,7 +10,7 @@ import Foundation
 import XcodeReleases
 
 let xcodes6: Array<Xcode> = [
-    
+
     Xcode(number: "6.4",
           build: "6E35b",
           releaseKind: .release,
@@ -210,7 +210,7 @@ let xcodes6: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.1.1/Xcode_6.1.1.dmg",
-                   sha1: "a54e4b327889e3ee3c952ef5292adc076c21df02"),
+                   sha1: "54ef00da0ec824c0d91c1338fc6090af660a6bf0"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW423")
           ]),
 
@@ -238,7 +238,7 @@ let xcodes6: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.1/Xcode_6.1.dmg",
-                   sha1: "4fc070a1347cc880ab2ed2225a7c9e4d5d6515c0"),
+                   sha1: "9f2c8a3be6edb73066300109f39aa3b25ee9c3c6"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW432")
           ]),
 
@@ -270,7 +270,7 @@ let xcodes6: Array<Xcode> = [
           ],
           links: [
             .xcode("https://download.developer.apple.com/Developer_Tools/xcode_6.0.1/Xcode_6.0.1.dmg",
-                   sha1: "496d56181861dd7ed1807895897d45403eb4ed44"),
+                   sha1: "b9595e4c1952ace9c5b0954778b54c4d521b66fb"),
             .notes("https://developer.apple.com/library/content/releasenotes/DeveloperTools/RN-Xcode/Chapters/Introduction.html#//apple_ref/doc/uid/TP40001051-CH1-SW450")
           ]),
 


### PR DESCRIPTION
Hi! Thanks for this great resource, and for being so quick to update it with every release 🙂

I went to download Xcode 5.1.1 for a project I’m working on, but I found that the download link was incorrect (403). As it happens, the wiki I run also maintains a [list of Xcode downloads](https://theapplewiki.com/wiki/Xcode), and those appear to be correct, so I synced up links that were incorrect, which worked out to the range of Xcode 4.3 - 6.1.1.

Some were just incorrect due to case sensitivity, while others look like they could have been incorrectly linking to beta builds (which have long been deleted). None of the sha1s matched - any idea why? I only downloaded the ones that changed here, haven’t checked others.

There are also some versions that are missing downloads (and SDK versions etc) in this data, but are still available to download. When I get time, I might follow up to add those.